### PR TITLE
Fix Issue #10

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -195,10 +195,11 @@ pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
 }
 
 /// Retrieves the name of a interface address
-unsafe fn get_ifa_name(ifa: *mut *mut ifaddrs) -> Result<String, Error> {
-    let str = (*(*ifa)).ifa_name as *mut u8;
-    let len = strlen(str as *const i8);
-    let slice = std::slice::from_raw_parts(str, len);
+fn get_ifa_name(ifa: *mut *mut ifaddrs) -> Result<String, Error> {
+    let str = unsafe { (*(*ifa)).ifa_name as *const libc::c_char };
+    let len = unsafe { strlen(str) };
+    let slice = unsafe { std::slice::from_raw_parts(str as *const u8, len) };
+
     match String::from_utf8(slice.to_vec()) {
         Ok(s) => Ok(s),
         Err(e) => Err(Error::StrategyError(format!(


### PR DESCRIPTION
Referenced in https://github.com/EstebanBorai/local-ip-address/issues/10

This issue was causing the Linux flavor of `local-ip-address` to not compile on Raspberry Pi due to a system value being cast to a `*const i8` as opposed to a `*const u8` in an `unsafe` block. Swapping the one character got it to compile without issue on my Raspberry Pi, and I was back up and running.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
