### PR TITLE
Fix | Windows | Use `DnsSuffix` instead of `FriendlyName`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub fn local_ip() -> Result<IpAddr, Error> {
 
         let ifas = crate::windows::list_afinet_netifas()?;
 
-        if let Some((_, ipaddr)) = find_ifa(ifas, "Ethernet") {
+        if let Some((_, ipaddr)) = find_ifa(ifas, "lan") {
             return Ok(ipaddr);
         }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,7 @@
 mod bindings {
     windows::include_bindings!();
 }
+
 use libc::{wchar_t, wcslen};
 use memalloc::{allocate, deallocate};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -69,7 +70,7 @@ pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
         let mut cur = mem;
 
         while !cur.is_null() {
-            let fname = unsafe { (*cur).FriendlyName.0 };
+            let fname = unsafe { (*cur).DnsSuffix.0 };
             let len = unsafe { wcslen(fname as *const wchar_t) };
             let slice = unsafe { std::slice::from_raw_parts(fname, len) };
 


### PR DESCRIPTION
Implements the use of the `DnsSuffix` over the `FriendlyName` for
network adapter names in order to bring support for Windows 10
versions in different languages.

Related issue: https://github.com/EstebanBorai/local-ip-address/issues/18
Realted documentation: https://docs.microsoft.com/en-us/windows/win32/api/iptypes/ns-iptypes-ip_adapter_addresses_lh

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
