### PR TITLE
fix: ignore interface with no link address

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -146,6 +146,13 @@ pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
         while !(**ifa).ifa_next.is_null() {
             let ifa_addr = (**ifa).ifa_addr;
 
+            // If a tun device is present, no link address is assigned to it and `ifa_addr` is null.
+            // See https://github.com/EstebanBorai/local-ip-address/issues/24
+            if ifa_addr.is_null() {
+                *ifa = (**ifa).ifa_next;
+                continue;
+            }
+
             match (*ifa_addr).sa_family as i32 {
                 // AF_INET IPv4 protocol implementation
                 AF_INET => {


### PR DESCRIPTION
Temporary fix to be able to use the library even in case of tun device. See https://github.com/EstebanBorai/local-ip-address/issues/24

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
