### PR TITLE
fix: replace `libc::malloc` with `std::alloc::alloc`

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,3 +1,4 @@
+use std::alloc::{alloc, dealloc, Layout};
 use std::mem;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use neli::attr::Attribute;
@@ -120,10 +121,10 @@ type IfAddrsPtr = *mut *mut ifaddrs;
 /// }
 /// ```
 pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
-    let ifaddrs_size = mem::size_of::<IfAddrsPtr>();
-
     unsafe {
-        let myaddr: IfAddrsPtr = libc::malloc(ifaddrs_size) as IfAddrsPtr;
+        let layout = Layout::new::<IfAddrsPtr>();
+        let ptr = alloc(layout);
+        let myaddr = ptr as IfAddrsPtr;
         let getifaddrs_result = getifaddrs(myaddr);
 
         if getifaddrs_result != 0 {
@@ -197,6 +198,7 @@ pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
             }
         }
 
+        dealloc(ptr, layout);
         Ok(interfaces)
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,5 +1,4 @@
 use std::alloc::{alloc, dealloc, Layout};
-use std::mem;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use neli::attr::Attribute;
 use neli::consts::nl::{NlmF, NlmFFlags};

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,4 +1,5 @@
 use libc::{getifaddrs, ifaddrs, sockaddr_in, sockaddr_in6, strlen, AF_INET, AF_INET6};
+use std::alloc::{alloc, dealloc, Layout};
 use std::mem;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
@@ -27,10 +28,9 @@ type IfAddrsPtr = *mut *mut ifaddrs;
 /// }
 /// ```
 pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
-    let ifaddrs_size = mem::size_of::<IfAddrsPtr>();
-
     unsafe {
-        let myaddr: IfAddrsPtr = libc::malloc(ifaddrs_size) as IfAddrsPtr;
+        let layout = Layout::new::<IfAddrsPtr>();
+        let myaddr: IfAddrsPtr = alloc(layout) as IfAddrsPtr;
         let getifaddrs_result = getifaddrs(myaddr);
 
         if getifaddrs_result != 0 {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -30,7 +30,8 @@ type IfAddrsPtr = *mut *mut ifaddrs;
 pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
     unsafe {
         let layout = Layout::new::<IfAddrsPtr>();
-        let myaddr: IfAddrsPtr = alloc(layout) as IfAddrsPtr;
+        let ptr = alloc(layout);
+        let myaddr = ptr as IfAddrsPtr;
         let getifaddrs_result = getifaddrs(myaddr);
 
         if getifaddrs_result != 0 {
@@ -97,6 +98,7 @@ pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
             }
         }
 
+        dealloc(ptr, layout);
         Ok(interfaces)
     }
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,6 +1,5 @@
 use libc::{getifaddrs, ifaddrs, sockaddr_in, sockaddr_in6, strlen, AF_INET, AF_INET6};
 use std::alloc::{alloc, dealloc, Layout};
-use std::mem;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::Error;


### PR DESCRIPTION
Replaces `libc::malloc` with `std::alloc::alloc` to avoid undefined behavior
on certain systems.

Refer: https://github.com/EstebanBorai/local-ip-address/issues/80

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
