### PR TITLE
Implement CI workflow for FreeBSD using Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -46,9 +46,12 @@ cargo_cache:
 task:
   name: "Runs \"cargo test\" on FreeBSD 13"
   <<: *SETUP
+  env:
+    RUSTFLAGS: "-D warnings"
+    RUSTDOCFLAGS: -D warnings
   test_script:
     - . $HOME/.cargo/env || true
-    - cargo test --all --all-features -- --nocapture -D warnings
+    - cargo test --all --all-features -- --nocapture
     - cargo doc --no-deps --target $TARGET
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
@@ -56,6 +59,8 @@ task:
 task:
   name: "Builds on FreeBSD 13"
   <<: *SETUP
+  env:
+    RUSTFLAGS: "-D warnings"
   test_script:
     - . $HOME/.cargo/env || true
     - cargo build +$TOOLCHAIN --release --target $TARGET --all-targets
@@ -68,7 +73,7 @@ task:
   install_script: rustup component add --toolchain $TOOLCHAIN clippy
   test_script:
     - . $HOME/.cargo/env || true
-    - cargo clippy --target $TARGET --all-targets -- -D warnings
+    - cargo clippy --target $TARGET --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Fmt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ env:
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
   TESTFLAGS: -- --nocapture
-  TOOL: carg
+  TOOL: cargo
   # The minimum supported Rust version (MSRV)
   # https://github.com/foresterre/cargo-msrv
   TOOLCHAIN: 1.56.1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,4 @@
+############################################################################
 # Cirrus workflow for testing on (Free)BSD.
 #
 # References:
@@ -7,8 +8,17 @@
 #   - https://github.com/jakewilliami/HiddenFiles.jl/blob/master/.cirrus.yml
 #
 # TODO:
-#   - Research best way to have different tests (one task with matrix or multiple tasks)
-#   - Implement tests for other BSD OS's (will need to handle setup differently for Tier 3 support OS's)
+#   - Implement tests for other BSD OS's (will need to handle setup
+#       differently for Tier 3 support OS's)
+############################################################################
+
+# Specify container (FreeBSD)
+#
+# References:
+#   - https://cirrus-ci.org/guide/writing-tasks/#execution-environment
+#   - https://cirrus-ci.org/guide/FreeBSD/
+freebsd_instance:
+  image: freebsd-13-1-release-amd64  # freebsd-12-3-release-amd64
 
 # Set up environment variables
 env:
@@ -32,41 +42,41 @@ cargo_cache:
   folder: $CARGO_HOME/registry
   fingerprint_script: cat Cargo.lock || echo ""
 
+# Run Unit Tests
 task:
-  # Specify container (FreeBSD): https://cirrus-ci.org/guide/writing-tasks/#execution-environment
-  freebsd_instance:
-    image: freebsd-13-1-release-amd64  # freebsd-12-3-release-amd64
-
-  # Set up Rust environment using Rustup
+  name: "Runs \"cargo test\" on FreeBSD 13"
   <<: *SETUP
+  test_script:
+    - cargo test --all --all-features -- --nocapture -D warnings
+    - cargo doc --no-deps --target $TARGET
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-  matrix:
-    # Run Unit Tests
-    - name: "Runs \"cargo test\" on FreeBSD 13"
-      setup_script: . $HOME/.cargo/env || true
-      test_script:
-        - cargo test --all --all-features -- --nocapture -D warnings
-        - cargo doc --no-deps --target $TARGET
-      before_cache_script: rm -rf $CARGO_HOME/registry/index
+# Test Cargo Build
+task:
+  name: "Builds on FreeBSD 13"
+  <<: *SETUP
+  test_script: cargo build +$TOOLCHAIN --release --target $TARGET --all-targets
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-    # Test Cargo Build
-    - name: "Builds on FreeBSD 13"
-      setup_script: . $HOME/.cargo/env || true
-      test_script: cargo build +$TOOLCHAIN --release --target $TARGET --all-targets
+# Test Cargo Clippy
+task:
+  name: "Runs \"cargo clippy\" on FreeBSD 13"
+  <<: *SETUP
+  install_script: rustup component add --toolchain $TOOLCHAIN clippy
+  test_script: cargo clippy --target $TARGET --all-targets -- -D warnings
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-    # Test Cargo Clippy
-    - name: "Runs \"cargo clippy\" on FreeBSD 13"
-      setup_script: . $HOME/.cargo/env || true
-      install_script: rustup component add --toolchain $TOOLCHAIN clippy
-      test_script: cargo clippy --target $TARGET --all-targets -- -D warnings
+# Test Cargo Fmt
+task:
+  name: "Runs \"cargo fmt\" on FreeBSD 13"
+  <<: *SETUP
+  install_script: rustup +$TOOLCHAIN component add rustfmt
+  test_script: cargo fmt --all -- --check
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
 
-    # Test Cargo Fmt
-    - name: "Runs \"cargo fmt\" on FreeBSD 13"
-      setup_script: . $HOME/.cargo/env || true
-      install_script: rustup +$TOOLCHAIN component add rustfmt
-      test_script: cargo fmt --all -- --check
-
-    # Test Cargo Publish
-    - name: "Runs \"cargo publish --dry-run\" on FreeBSD 13"
-      setup_script: . $HOME/.cargo/env || true
-      test_script: cargo publish --dry-run
+# Test Cargo Publish
+task:
+  name: "Runs \"cargo publish --dry-run\" on FreeBSD 13"
+  <<: *SETUP
+  test_script: cargo publish --dry-run
+  before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,25 +12,19 @@
 
 # Set up environment variables
 env:
-  BUILD: build
-  RUSTFLAGS: -D warnings
-  RUSTDOCFLAGS: -D warnings
-  TESTFLAGS: -- --nocapture
-  TOOL: cargo
   # The minimum supported Rust version (MSRV)
   # https://github.com/foresterre/cargo-msrv
   TOOLCHAIN: 1.56.1
-  ZFLAGS:
 
 # Define set up procedure by downloading Rustup (to consume later)
 setup_common: &SETUP
-  setup_script:  # install_script
+  setup_script:
     - kldload mqueuefs
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile=minimal --default-toolchain $TOOLCHAIN
-    - . $HOME/.cargo/env || true
     - rustup component add --toolchain $TOOLCHAIN clippy
-    - $TOOL -Vv
+    - . $HOME/.cargo/env || true
+    - cargo -Vv
     - rustc -Vv
 
 # Cache the Cargo directory between runs
@@ -47,20 +41,27 @@ task:
   <<: *SETUP
 
   matrix:
+    # Run Unit Tests
     - name: "Runs \"cargo test\" on FreeBSD 13"
       test_script:
-        - $TOOL test -- --nocapture $RUSTFLAGS  # --all --all-features
-        - $TOOL doc $ZFLAGS --no-deps --target $TARGET $RUSTDOCFLAGS
+        - cargo test --all --all-features -- --nocapture -D warnings
+        - cargo doc --no-deps --target $TARGET
       before_cache_script: rm -rf $CARGO_HOME/registry/index
+
+    # Test Cargo Build
     - name: "Builds on FreeBSD 13"
-      test_script:
-        - $TOOL $BUILD $ZFLAGS --target $TARGET --all-targets
+      test_script: cargo build +$TOOLCHAIN --release --target $TARGET --all-targets
+
+    # Test Cargo Clippy
     - name: "Runs \"cargo clippy\" on FreeBSD 13"
-      test_script:
-        - $TOOL clippy $ZFLAGS --target $TARGET --all-targets -- $RUSTFLAGS
+      install_script: rustup component add --toolchain $TOOLCHAIN clippy
+      test_script: cargo clippy --target $TARGET --all-targets -- -D warnings
+
+    # Test Cargo Fmt
     - name: "Runs \"cargo fmt\" on FreeBSD 13"
-      test_script:
-        - $TOOL fmt
+      install_script: rustup +$TOOLCHAIN component add rustfmt
+      test_script: cargo fmt --all -- --check
+
+    # Test Cargo Publish
     - name: "Runs \"cargo publish --dry-run\" on FreeBSD 13"
-      test_script:
-        - $TOOL publish --dry-run
+      test_script: cargo publish --dry-run

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,75 @@
+# Cirrus workflow for testing on (Free)BSD.
+#
+# References:
+#   - https://cirrus-ci.org/guide/writing-tasks/
+#   - https://github.com/tokio-rs/tokio/blob/master/.cirrus.yml
+#   - https://github.com/nix-rust/nix/blob/master/.cirrus.yml
+#   - https://github.com/jakewilliami/HiddenFiles.jl/blob/master/.cirrus.yml
+#
+# TODO:
+#   - Research best way to have different tests (one task with matrix or multiple tasks)
+#   - Implement tests for other BSD OS's (will need to handle setup differently for Tier 3 support OS's)
+
+# Set up environment variables
+env:
+  BUILD: build
+  RUSTFLAGS: -D warnings
+  RUSTDOCFLAGS: -D warnings
+  TESTFLAGS: -- --nocapture
+  TOOL: cargo
+  TOOLCHAIN: 1
+  ZFLAGS:
+
+# Define set up procedure by downloading Rustup (to consume later)
+setup_common: &SETUP
+  setup_script:  # install_script
+    - pkg install -y bash curl
+    - curl https://sh.rustup.rs -sSf --output rustup.sh
+    - sh rustup.sh -y --profile minimal --default-toolchain $RUST_STABLE
+
+# Cache the Cargo directory between runs
+cargo_cache:
+  folder: $CARGO_HOME/registry
+  fingerprint_script: cat Cargo.lock || echo ""
+
+task:
+  # Specify container (FreeBSD): https://cirrus-ci.org/guide/writing-tasks/#execution-environment
+  freebsd_instance:
+    image: freebsd-12-3-release-amd64  # freebsd-13-1-release-amd64
+
+  # Set up Rust environment using Rustup
+  <<: *SETUP
+
+  matrix:
+    - name: "Runs \"cargo test\" on FreeBSD 12"
+      test_script:
+        - . $HOME/.cargo/env || true
+        - $TOOL -Vv
+        - rustc -Vv
+        - $TOOL test -- --nocapture $RUSTFLAGS  # --all --all-features
+        - $TOOL doc $ZFLAGS --no-deps --target $TARGET $RUSTDOCFLAGS
+      before_cache_script: rm -rf $CARGO_HOME/registry/index
+    - name: "Builds on FreeBSD 12"
+      test_script:
+        - . $HOME/.cargo/env || true
+        - $TOOL -Vv
+        - rustc -Vv
+        - $TOOL $BUILD $ZFLAGS --target $TARGET --all-targets
+    - name: "Runs \"cargo clippy\" on FreeBSD 12"
+      test_script:
+        - . $HOME/.cargo/env || true
+        - $TOOL -Vv
+        - rustc -Vv
+        - $TOOL clippy $ZFLAGS --target $TARGET --all-targets -- $RUSTFLAGS
+    - name: "Runs \"cargo fmt\" on FreeBSD 12"
+      test_script:
+        - . $HOME/.cargo/env || true
+        - $TOOL -Vv
+        - rustc -Vv
+        - $TOOL fmt
+    - name: "Runs \"cargo publish --dry-run\" on FreeBSD 12"
+      test_script:
+        - . $HOME/.cargo/env || true
+        - $TOOL -Vv
+        - rustc -Vv
+        - $TOOL publish --dry-run

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,6 +23,7 @@ setup_common: &SETUP
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile=minimal --default-toolchain $TOOLCHAIN
     - . $HOME/.cargo/env || true
+    - rustup --version
     - cargo -Vv
     - rustc -Vv
 
@@ -42,6 +43,7 @@ task:
   matrix:
     # Run Unit Tests
     - name: "Runs \"cargo test\" on FreeBSD 13"
+      setup_script: . $HOME/.cargo/env || true
       test_script:
         - cargo test --all --all-features -- --nocapture -D warnings
         - cargo doc --no-deps --target $TARGET
@@ -49,18 +51,22 @@ task:
 
     # Test Cargo Build
     - name: "Builds on FreeBSD 13"
+      setup_script: . $HOME/.cargo/env || true
       test_script: cargo build +$TOOLCHAIN --release --target $TARGET --all-targets
 
     # Test Cargo Clippy
     - name: "Runs \"cargo clippy\" on FreeBSD 13"
+      setup_script: . $HOME/.cargo/env || true
       install_script: rustup component add --toolchain $TOOLCHAIN clippy
       test_script: cargo clippy --target $TARGET --all-targets -- -D warnings
 
     # Test Cargo Fmt
     - name: "Runs \"cargo fmt\" on FreeBSD 13"
+      setup_script: . $HOME/.cargo/env || true
       install_script: rustup +$TOOLCHAIN component add rustfmt
       test_script: cargo fmt --all -- --check
 
     # Test Cargo Publish
     - name: "Runs \"cargo publish --dry-run\" on FreeBSD 13"
+      setup_script: . $HOME/.cargo/env || true
       test_script: cargo publish --dry-run

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,6 @@ setup_common: &SETUP
     - kldload mqueuefs
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile=minimal --default-toolchain $TOOLCHAIN
-    - rustup component add --toolchain $TOOLCHAIN clippy
     - . $HOME/.cargo/env || true
     - cargo -Vv
     - rustc -Vv

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -51,8 +51,8 @@ task:
     RUSTDOCFLAGS: -D warnings
   test_script:
     - . $HOME/.cargo/env || true
-    - cargo test --all --all-features -- --nocapture
-    - cargo doc --no-deps --target $TARGET
+    - cargo +$TOOLCHAIN test --all --all-features -- --nocapture
+    - cargo +$TOOLCHAIN doc --no-deps --target $TARGET
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Build
@@ -63,7 +63,7 @@ task:
     RUSTFLAGS: "-D warnings"
   test_script:
     - . $HOME/.cargo/env || true
-    - cargo build +$TOOLCHAIN --release --target $TARGET --all-targets
+    - cargo +$TOOLCHAIN build --release --target $TARGET --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Clippy
@@ -73,7 +73,7 @@ task:
   install_script: rustup component add --toolchain $TOOLCHAIN clippy
   test_script:
     - . $HOME/.cargo/env || true
-    - cargo clippy --target $TARGET --all-targets
+    - cargo +$TOOLCHAIN clippy --target $TARGET --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Fmt
@@ -83,7 +83,7 @@ task:
   install_script: rustup +$TOOLCHAIN component add rustfmt
   test_script:
     - . $HOME/.cargo/env || true
-    - cargo fmt --all -- --check
+    - cargo +$TOOLCHAIN fmt --all -- --check
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Publish
@@ -92,5 +92,5 @@ task:
   <<: *SETUP
   test_script:
     - . $HOME/.cargo/env || true
-    - cargo publish --dry-run
+    - cargo +$TOOLCHAIN publish --dry-run
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,6 +37,7 @@ setup_common: &SETUP
     - rustup --version
     - cargo -Vv
     - rustc -Vv
+    - ifconfig
 
 # Cache the Cargo directory between runs
 cargo_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,10 +25,11 @@ env:
 # Define set up procedure by downloading Rustup (to consume later)
 setup_common: &SETUP
   setup_script:  # install_script
-    - pkg install -y bash curl
-    - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile minimal --default-toolchain $RUST_STABLE
+    - kldload mqueuefs
+    - fetch https://sh.rustup.rs -o rustup.sh
+    - sh rustup.sh -y --profile=minimal --default-toolchain $TOOLCHAIN
     - . $HOME/.cargo/env || true
+    - rustup component add --toolchain $TOOLCHAIN clippy
     - $TOOL -Vv
     - rustc -Vv
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -70,7 +70,9 @@ task:
 task:
   name: "Runs \"cargo clippy\" on FreeBSD 13"
   <<: *SETUP
-  install_script: rustup component add --toolchain $TOOLCHAIN clippy
+  install_script:
+    - . $HOME/.cargo/env || true
+    - rustup component add --toolchain $TOOLCHAIN clippy
   test_script:
     - . $HOME/.cargo/env || true
     - cargo +$TOOLCHAIN clippy --target $TARGET --all-targets
@@ -80,7 +82,9 @@ task:
 task:
   name: "Runs \"cargo fmt\" on FreeBSD 13"
   <<: *SETUP
-  install_script: rustup +$TOOLCHAIN component add rustfmt
+  install_script:
+    - . $HOME/.cargo/env || true
+    - rustup +$TOOLCHAIN component add rustfmt
   test_script:
     - . $HOME/.cargo/env || true
     - cargo +$TOOLCHAIN fmt --all -- --check

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -32,6 +32,7 @@ setup_common: &SETUP
     - kldload mqueuefs
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile=minimal --default-toolchain $TOOLCHAIN
+    - rm rustup.sh
     - . $HOME/.cargo/env || true
     - rustup --version
     - cargo -Vv

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,6 +28,9 @@ setup_common: &SETUP
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y --profile minimal --default-toolchain $RUST_STABLE
+    - . $HOME/.cargo/env || true
+    - $TOOL -Vv
+    - rustc -Vv
 
 # Cache the Cargo directory between runs
 cargo_cache:
@@ -45,33 +48,18 @@ task:
   matrix:
     - name: "Runs \"cargo test\" on FreeBSD 12"
       test_script:
-        - . $HOME/.cargo/env || true
-        - $TOOL -Vv
-        - rustc -Vv
         - $TOOL test -- --nocapture $RUSTFLAGS  # --all --all-features
         - $TOOL doc $ZFLAGS --no-deps --target $TARGET $RUSTDOCFLAGS
       before_cache_script: rm -rf $CARGO_HOME/registry/index
     - name: "Builds on FreeBSD 12"
       test_script:
-        - . $HOME/.cargo/env || true
-        - $TOOL -Vv
-        - rustc -Vv
         - $TOOL $BUILD $ZFLAGS --target $TARGET --all-targets
     - name: "Runs \"cargo clippy\" on FreeBSD 12"
       test_script:
-        - . $HOME/.cargo/env || true
-        - $TOOL -Vv
-        - rustc -Vv
         - $TOOL clippy $ZFLAGS --target $TARGET --all-targets -- $RUSTFLAGS
     - name: "Runs \"cargo fmt\" on FreeBSD 12"
       test_script:
-        - . $HOME/.cargo/env || true
-        - $TOOL -Vv
-        - rustc -Vv
         - $TOOL fmt
     - name: "Runs \"cargo publish --dry-run\" on FreeBSD 12"
       test_script:
-        - . $HOME/.cargo/env || true
-        - $TOOL -Vv
-        - rustc -Vv
         - $TOOL publish --dry-run

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,8 +16,10 @@ env:
   RUSTFLAGS: -D warnings
   RUSTDOCFLAGS: -D warnings
   TESTFLAGS: -- --nocapture
-  TOOL: cargo
-  TOOLCHAIN: 1
+  TOOL: carg
+  # The minimum supported Rust version (MSRV)
+  # https://github.com/foresterre/cargo-msrv
+  TOOLCHAIN: 1.56.1
   ZFLAGS:
 
 # Define set up procedure by downloading Rustup (to consume later)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -47,6 +47,7 @@ task:
   name: "Runs \"cargo test\" on FreeBSD 13"
   <<: *SETUP
   test_script:
+    - . $HOME/.cargo/env || true
     - cargo test --all --all-features -- --nocapture -D warnings
     - cargo doc --no-deps --target $TARGET
   before_cache_script: rm -rf $CARGO_HOME/registry/index
@@ -55,7 +56,9 @@ task:
 task:
   name: "Builds on FreeBSD 13"
   <<: *SETUP
-  test_script: cargo build +$TOOLCHAIN --release --target $TARGET --all-targets
+  test_script:
+    - . $HOME/.cargo/env || true
+    - cargo build +$TOOLCHAIN --release --target $TARGET --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Clippy
@@ -63,7 +66,9 @@ task:
   name: "Runs \"cargo clippy\" on FreeBSD 13"
   <<: *SETUP
   install_script: rustup component add --toolchain $TOOLCHAIN clippy
-  test_script: cargo clippy --target $TARGET --all-targets -- -D warnings
+  test_script:
+    - . $HOME/.cargo/env || true
+    - cargo clippy --target $TARGET --all-targets -- -D warnings
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Fmt
@@ -71,12 +76,16 @@ task:
   name: "Runs \"cargo fmt\" on FreeBSD 13"
   <<: *SETUP
   install_script: rustup +$TOOLCHAIN component add rustfmt
-  test_script: cargo fmt --all -- --check
+  test_script:
+    - . $HOME/.cargo/env || true
+    - cargo fmt --all -- --check
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Publish
 task:
   name: "Runs \"cargo publish --dry-run\" on FreeBSD 13"
   <<: *SETUP
-  test_script: cargo publish --dry-run
+  test_script:
+    - . $HOME/.cargo/env || true
+    - cargo publish --dry-run
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,6 +43,17 @@ cargo_cache:
   folder: $CARGO_HOME/registry
   fingerprint_script: cat Cargo.lock || echo ""
 
+# Test Cargo Build
+task:
+  name: "Builds on FreeBSD 13"
+  <<: *SETUP
+  env:
+    RUSTFLAGS: "-D warnings"
+  test_script:
+    - . $HOME/.cargo/env || true
+    - cargo +$TOOLCHAIN build --release --all-targets
+  before_cache_script: rm -rf $CARGO_HOME/registry/index
+
 # Run Unit Tests
 task:
   name: "Runs \"cargo test\" on FreeBSD 13"
@@ -53,18 +64,7 @@ task:
   test_script:
     - . $HOME/.cargo/env || true
     - cargo +$TOOLCHAIN test --all --all-features -- --nocapture
-    - cargo +$TOOLCHAIN doc --no-deps --target $TARGET
-  before_cache_script: rm -rf $CARGO_HOME/registry/index
-
-# Test Cargo Build
-task:
-  name: "Builds on FreeBSD 13"
-  <<: *SETUP
-  env:
-    RUSTFLAGS: "-D warnings"
-  test_script:
-    - . $HOME/.cargo/env || true
-    - cargo +$TOOLCHAIN build --release --target $TARGET --all-targets
+    - cargo +$TOOLCHAIN doc --no-deps
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Clippy
@@ -76,7 +76,7 @@ task:
     - rustup component add --toolchain $TOOLCHAIN clippy
   test_script:
     - . $HOME/.cargo/env || true
-    - cargo +$TOOLCHAIN clippy --target $TARGET --all-targets
+    - cargo +$TOOLCHAIN clippy --all-targets
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 # Test Cargo Fmt

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,26 +41,26 @@ cargo_cache:
 task:
   # Specify container (FreeBSD): https://cirrus-ci.org/guide/writing-tasks/#execution-environment
   freebsd_instance:
-    image: freebsd-12-3-release-amd64  # freebsd-13-1-release-amd64
+    image: freebsd-13-1-release-amd64  # freebsd-12-3-release-amd64
 
   # Set up Rust environment using Rustup
   <<: *SETUP
 
   matrix:
-    - name: "Runs \"cargo test\" on FreeBSD 12"
+    - name: "Runs \"cargo test\" on FreeBSD 13"
       test_script:
         - $TOOL test -- --nocapture $RUSTFLAGS  # --all --all-features
         - $TOOL doc $ZFLAGS --no-deps --target $TARGET $RUSTDOCFLAGS
       before_cache_script: rm -rf $CARGO_HOME/registry/index
-    - name: "Builds on FreeBSD 12"
+    - name: "Builds on FreeBSD 13"
       test_script:
         - $TOOL $BUILD $ZFLAGS --target $TARGET --all-targets
-    - name: "Runs \"cargo clippy\" on FreeBSD 12"
+    - name: "Runs \"cargo clippy\" on FreeBSD 13"
       test_script:
         - $TOOL clippy $ZFLAGS --target $TARGET --all-targets -- $RUSTFLAGS
-    - name: "Runs \"cargo fmt\" on FreeBSD 12"
+    - name: "Runs \"cargo fmt\" on FreeBSD 13"
       test_script:
         - $TOOL fmt
-    - name: "Runs \"cargo publish --dry-run\" on FreeBSD 12"
+    - name: "Runs \"cargo publish --dry-run\" on FreeBSD 13"
       test_script:
         - $TOOL publish --dry-run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub fn local_ip() -> Result<IpAddr, Error> {
     {
         let ifas = crate::bsd::list_afinet_netifas()?;
 
-        if let Some((_, ipaddr)) = find_ifa(ifas, "en0") {
+        if let Some((_, ipaddr)) = find_ifa(ifas, vec!["en0", "epair0b"]) {
             return Ok(ipaddr);
         }
 
@@ -157,11 +157,12 @@ pub fn local_ip() -> Result<IpAddr, Error> {
     }
 }
 
-/// Finds the network interface with the provided name in the vector of network
+/// Finds the network interface with any of the provided names in the vector of network
 /// interfaces provided
-pub fn find_ifa(ifas: Vec<(String, IpAddr)>, ifa_name: &str) -> Option<(String, IpAddr)> {
-    ifas.into_iter()
-        .find(|(name, ipaddr)| name == ifa_name && matches!(ipaddr, IpAddr::V4(_)))
+pub fn find_ifa(ifas: Vec<(String, IpAddr)>, ifa_names: Vec<&str>) -> Option<(String, IpAddr)> {
+    ifas.into_iter().find(|(name, ipaddr)| {
+        ifa_names.contains(&name.as_str()) && matches!(ipaddr, IpAddr::V4(_))
+    })
 }
 
 // A catch-all function to error if not implemented for OS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,12 +192,18 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+    ))]
     fn find_local_ip() {
         let my_local_ip = local_ip();
 
         assert!(matches!(my_local_ip, Ok(IpAddr::V4(_))));
-        println!("macOS 'local_ip': {:?}", my_local_ip);
+        println!("BSD 'local_ip': {:?}", my_local_ip);
     }
 
     #[test]
@@ -219,7 +225,13 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "macos")]
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+    ))]
     fn find_network_interfaces() {
         let network_interfaces = list_afinet_netifas();
 


### PR DESCRIPTION
### Summary
This PR implements CI workflow for FreeBSD using Cirrus CI, as previously discussed.<sup>[[1]](https://github.com/EstebanBorai/local-ip-address/pull/85#issuecomment-1312852325), [[2]](https://github.com/EstebanBorai/local-ip-address/pull/87#issuecomment-1315129507)</sup>

In this PR, I also had to fix an error in correctly obtaining the local IP in BSD.

---

### Requirement(s) from project owner:
  - [x] Allow Cirrus CI access to this repository<sup>[[3]](https://cirrus-ci.org/guide/quick-start/)</sup>

### Point(s) for reviewer to check:
  - [ ] Confirm consistency of Cirrus CI with existing GitHub workflows
  - [ ] Check fix for FreeBSD `local_ip` implementation is correct

### Points to consider implementing before merge:
  - Dynamically obtain local IP interface name for BSD implementation rather than using hard-coded interface names

### Notes/discoveries:
  - When fixing tests for FreeBSD, I had to modify the `find_ifa` function&mdash;renamed to `find_ifas`&mdash;and the `list_afinet_netifas` function.
  - The [nix](https://github.com/nix-rust/nix/) package implements the functionality in this project, though its scope is far greater than the likes of this library.