### PR TITLE
fix(linux): off by one error caused `list_afinet_netifas` to omit the last ip address

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -156,58 +156,54 @@ pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
         // To find the relevant interface address walk over the nodes of the
         // linked list looking for interface address which belong to the socket
         // address families AF_INET (IPv4) and AF_INET6 (IPv6)
-        while !(*ifa).ifa_next.is_null() {
+        loop {
             let ifa_addr = (*ifa).ifa_addr;
 
             // If a tun device is present, no link address is assigned to it and `ifa_addr` is null.
             // See https://github.com/EstebanBorai/local-ip-address/issues/24
-            if ifa_addr.is_null() {
-                ifa = (*ifa).ifa_next;
-                continue;
-            }
+            if !ifa_addr.is_null() {
+                match (*ifa_addr).sa_family as i32 {
+                    // AF_INET IPv4 protocol implementation
+                    AF_INET => {
+                        let interface_address = ifa_addr;
+                        let socket_addr_v4: *mut sockaddr_in =
+                            interface_address as *mut sockaddr_in;
+                        let in_addr = (*socket_addr_v4).sin_addr;
+                        let mut ip_addr = Ipv4Addr::from(in_addr.s_addr);
 
-            match (*ifa_addr).sa_family as i32 {
-                // AF_INET IPv4 protocol implementation
-                AF_INET => {
-                    let interface_address = ifa_addr;
-                    let socket_addr_v4: *mut sockaddr_in = interface_address as *mut sockaddr_in;
-                    let in_addr = (*socket_addr_v4).sin_addr;
-                    let mut ip_addr = Ipv4Addr::from(in_addr.s_addr);
+                        if cfg!(target_endian = "little") {
+                            // due to a difference on how bytes are arranged on a
+                            // single word of memory by the CPU, swap bytes based
+                            // on CPU endianess to avoid having twisted IP addresses
+                            //
+                            // refer: https://github.com/rust-lang/rust/issues/48819
+                            ip_addr = Ipv4Addr::from(in_addr.s_addr.swap_bytes());
+                        }
 
-                    if cfg!(target_endian = "little") {
-                        // due to a difference on how bytes are arranged on a
-                        // single word of memory by the CPU, swap bytes based
-                        // on CPU endianess to avoid having twisted IP addresses
-                        //
-                        // refer: https://github.com/rust-lang/rust/issues/48819
-                        ip_addr = Ipv4Addr::from(in_addr.s_addr.swap_bytes());
+                        let name = get_ifa_name(ifa)?;
+
+                        interfaces.push((name, IpAddr::V4(ip_addr)));
                     }
+                    // AF_INET6 IPv6 protocol implementation
+                    AF_INET6 => {
+                        let interface_address = ifa_addr;
+                        let socket_addr_v6: *mut sockaddr_in6 =
+                            interface_address as *mut sockaddr_in6;
+                        let in6_addr = (*socket_addr_v6).sin6_addr;
+                        let ip_addr = Ipv6Addr::from(in6_addr.s6_addr);
+                        let name = get_ifa_name(ifa)?;
 
-                    let name = get_ifa_name(ifa)?;
-
-                    interfaces.push((name, IpAddr::V4(ip_addr)));
-
-                    ifa = (*ifa).ifa_next;
-                    continue;
-                }
-                // AF_INET6 IPv6 protocol implementation
-                AF_INET6 => {
-                    let interface_address = ifa_addr;
-                    let socket_addr_v6: *mut sockaddr_in6 = interface_address as *mut sockaddr_in6;
-                    let in6_addr = (*socket_addr_v6).sin6_addr;
-                    let ip_addr = Ipv6Addr::from(in6_addr.s6_addr);
-                    let name = get_ifa_name(ifa)?;
-
-                    interfaces.push((name, IpAddr::V6(ip_addr)));
-
-                    ifa = (*ifa).ifa_next;
-                    continue;
-                }
-                _ => {
-                    ifa = (*ifa).ifa_next;
-                    continue;
+                        interfaces.push((name, IpAddr::V6(ip_addr)));
+                    }
+                    _ => {}
                 }
             }
+
+            if (*ifa).ifa_next.is_null() {
+                break;
+            }
+
+            ifa = (*ifa).ifa_next;
         }
 
         Ok(interfaces)


### PR DESCRIPTION
This PR fixes an issue in the Linux implementation where a `while` condition checked if the next item (`ifa_next`) would be null before it consumed the current item (`ifa`). This caused the loop to always skip the last ip address, causing it to be omitted from the list returned by `list_afinet_netifas()`.