### PR TITLE
Dynamically obtain local IP for BSD

### DIFF
--- a/src/bsd.rs
+++ b/src/bsd.rs
@@ -28,11 +28,10 @@ type IfAddrsPtr = *mut *mut ifaddrs;
 /// ```
 pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
     match list_afinet_netifas_info() {
-        Ok(interfaces) => {
-            Ok(interfaces.iter().map(|i| {
-                (i.iname.clone(), i.addr)
-            }).collect())
-        },
+        Ok(interfaces) => Ok(interfaces
+            .iter()
+            .map(|i| (i.iname.clone(), i.addr))
+            .collect()),
         Err(e) => Err(e),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,11 +121,17 @@ pub fn local_ip() -> Result<IpAddr, Error> {
         target_os = "dragonfly",
     ))]
     {
-        let ifas = crate::bsd::list_afinet_netifas()?;
+        let ifas = crate::bsd::list_afinet_netifas_info()?;
 
         ifas
             .into_iter()
-            .map(|(_iname, ip_addr)| ip_addr)
+            .filter_map(|interface| {
+                if interface.is_loopback {
+                    Some(interface.addr)
+                } else {
+                    None
+                }
+            })
             .find(|ip_addr| matches!(ip_addr, IpAddr::V4(_)))
             .ok_or_else(|| Error::PlatformNotSupported(env::consts::OS.to_string()))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,7 @@ pub fn local_ip() -> Result<IpAddr, Error> {
     {
         let ifas = crate::bsd::list_afinet_netifas_info()?;
 
-        ifas
-            .into_iter()
+        ifas.into_iter()
             .filter_map(|interface| {
                 if interface.is_loopback {
                     Some(interface.addr)


### PR DESCRIPTION
BSD local IP address was previously hard coded to look for specific interface names.  This pull request solves this by dynamically looking for the first non-loopback local IP in the interface list, which is required for tests to pass for BSD.

This would also close #82.

While this is probably a pretty good solution, it may not be perfect (see #94).