### PR TITLE
feat(linux): rewrite list_afinet_netifas 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1"
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-neli = "0.5"
+neli = "0.6"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.42.0"

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,16 +1,18 @@
+use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use neli::attr::Attribute;
 use neli::consts::nl::{NlmF, NlmFFlags};
 use neli::consts::socket::NlFamily;
 use neli::consts::rtnl::{
-    Ifa, IfaFFlags, RtAddrFamily, RtScope, Rtm, RtTable, Rtprot, Rtn, RtmFFlags, RtmF, Rta,
+    Ifa, IfaFFlags, RtAddrFamily, RtScope, Rtm, RtTable, Rtprot, Rtn, RtmFFlags, RtmF, Rta, Ifla,
 };
 use neli::nl::{NlPayload, Nlmsghdr};
-use neli::rtnl::{Ifaddrmsg, Rtattr, Rtmsg};
+use neli::rtnl::{Ifaddrmsg, Ifinfomsg, Rtattr, Rtmsg};
+
 use neli::socket::NlSocketHandle;
 use neli::types::RtBuffer;
-use libc::{freeifaddrs, getifaddrs, ifaddrs, sockaddr_in, sockaddr_in6, strlen, AF_INET, AF_INET6};
+use neli::consts::rtnl::RtAddrFamily::{Inet, Inet6};
 
 use crate::Error;
 
@@ -156,35 +158,7 @@ pub fn local_ip() -> Result<IpAddr, Error> {
     Err(Error::LocalIpAddressNotFound)
 }
 
-struct IfAddrList {
-    ptr: *mut ifaddrs,
-}
-
-impl IfAddrList {
-    fn new() -> Result<IfAddrList, Error> {
-        unsafe {
-            let mut ptr: *mut ifaddrs = std::ptr::null_mut();
-            let res = getifaddrs(&mut ptr);
-            if res != 0 || ptr.is_null() {
-                return Err(Error::StrategyError(format!(
-                    "getifaddrs(3) failed: {}",
-                    std::io::Error::last_os_error()
-                )));
-            }
-            Ok(IfAddrList { ptr })
-        }
-    }
-}
-
-impl Drop for IfAddrList {
-    fn drop(&mut self) {
-        unsafe {
-            freeifaddrs(self.ptr);
-        }
-    }
-}
-
-/// Perform a search over the system's network interfaces using `getifaddrs`,
+/// Perform a search over the system's network interfaces using Netlink Route information,
 /// retrieved network interfaces belonging to both socket address families
 /// `AF_INET` and `AF_INET6` are retrieved along with the interface address name.
 ///
@@ -204,83 +178,188 @@ impl Drop for IfAddrList {
 /// }
 /// ```
 pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
-    unsafe {
-        let ptr_ifaddrs = IfAddrList::new()?;
+    let mut netlink_socket = NlSocketHandle::connect(NlFamily::Route, None, &[])
+        .map_err(|err| Error::StrategyError(err.to_string()))?;
 
-        let mut interfaces: Vec<(String, IpAddr)> = Vec::new();
-        let mut ifa = ptr_ifaddrs.ptr as *const ifaddrs;
+    // First get list of interfaces via RTM_GETLINK
 
-        // An instance of `ifaddrs` is build on top of a linked list where
-        // `ifaddrs.ifa_next` represent the next node in the list.
-        //
-        // To find the relevant interface address walk over the nodes of the
-        // linked list looking for interface address which belong to the socket
-        // address families AF_INET (IPv4) and AF_INET6 (IPv6)
-        loop {
-            let ifa_addr = (*ifa).ifa_addr;
+    let ifroutemsg = Rtmsg {
+        rtm_family: RtAddrFamily::Unspecified,
+        rtm_dst_len: 0,
+        rtm_src_len: 0,
+        rtm_tos: 0,
+        rtm_table: RtTable::Unspec,
+        rtm_protocol: Rtprot::Unspec,
+        rtm_scope: RtScope::Universe,
+        rtm_type: Rtn::Unspec,
+        rtm_flags: RtmFFlags::new(&[RtmF::LookupTable]),
+        rtattrs: RtBuffer::new(),
+    };
+    let netlink_message = Nlmsghdr::new(
+        None,
+        Rtm::Getlink,
+        NlmFFlags::new(&[NlmF::Request, NlmF::Dump]),
+        None,
+        None,
+        NlPayload::Payload(ifroutemsg),
+    );
 
-            // If a tun device is present, no link address is assigned to it and `ifa_addr` is null.
-            // See https://github.com/EstebanBorai/local-ip-address/issues/24
-            if !ifa_addr.is_null() {
-                match (*ifa_addr).sa_family as i32 {
-                    // AF_INET IPv4 protocol implementation
-                    AF_INET => {
-                        let interface_address = ifa_addr;
-                        let socket_addr_v4: *mut sockaddr_in =
-                            interface_address as *mut sockaddr_in;
-                        let in_addr = (*socket_addr_v4).sin_addr;
-                        let mut ip_addr = Ipv4Addr::from(in_addr.s_addr);
+    netlink_socket
+        .send(netlink_message)
+        .map_err(|err| Error::StrategyError(err.to_string()))?;
 
-                        if cfg!(target_endian = "little") {
-                            // due to a difference on how bytes are arranged on a
-                            // single word of memory by the CPU, swap bytes based
-                            // on CPU endianess to avoid having twisted IP addresses
-                            //
-                            // refer: https://github.com/rust-lang/rust/issues/48819
-                            ip_addr = Ipv4Addr::from(in_addr.s_addr.swap_bytes());
-                        }
+    let mut if_indexes = HashMap::new();
 
-                        let name = get_ifa_name(ifa)?;
+    for response in netlink_socket.iter(false) {
+        let header: Nlmsghdr<Rtm, Ifinfomsg> = response.map_err(|_| {
+            Error::StrategyError(String::from(
+                "An error occurred retrieving Netlink's socket response",
+            ))
+        })?;
 
-                        interfaces.push((name, IpAddr::V4(ip_addr)));
-                    }
-                    // AF_INET6 IPv6 protocol implementation
-                    AF_INET6 => {
-                        let interface_address = ifa_addr;
-                        let socket_addr_v6: *mut sockaddr_in6 =
-                            interface_address as *mut sockaddr_in6;
-                        let in6_addr = (*socket_addr_v6).sin6_addr;
-                        let ip_addr = Ipv6Addr::from(in6_addr.s6_addr);
-                        let name = get_ifa_name(ifa)?;
-
-                        interfaces.push((name, IpAddr::V6(ip_addr)));
-                    }
-                    _ => {}
-                }
-            }
-
-            if (*ifa).ifa_next.is_null() {
-                break;
-            }
-
-            ifa = (*ifa).ifa_next;
+        if let NlPayload::Empty = header.nl_payload {
+            continue;
         }
 
-        Ok(interfaces)
-    }
-}
+        if header.nl_type != Rtm::Newlink {
+            return Err(Error::StrategyError(String::from(
+                "The Netlink header type is not the expected",
+            )));
+        }
 
-/// Retrieves the name of a interface address
-fn get_ifa_name(ifa: *const ifaddrs) -> Result<String, Error> {
-    let str = unsafe { (*ifa).ifa_name as *const libc::c_char };
-    let len = unsafe { strlen(str) };
-    let slice = unsafe { std::slice::from_raw_parts(str as *const u8, len) };
+        let p = header.get_payload().map_err(|_| {
+            Error::StrategyError(String::from(
+                "An error occurred getting Netlink's header payload",
+            ))
+        })?;
 
-    match String::from_utf8(slice.to_vec()) {
-        Ok(s) => Ok(s),
-        Err(e) => Err(Error::StrategyError(format!(
-            "Failed to retrieve interface name. The name is not a valid UTF-8 string. {}",
-            e
-        ))),
+        for rtattr in p.rtattrs.iter() {
+            if rtattr.rta_type == Ifla::Ifname {
+                let ifname = String::from_utf8_lossy(rtattr.payload().as_ref()).to_string();
+                if_indexes.insert(p.ifi_index, ifname);
+                break;
+            }
+        }
     }
+
+    // Secondly get addresses of interfaces via RTM_GETADDR
+
+    let ifroutemsg = Rtmsg {
+        rtm_family: RtAddrFamily::Unspecified,
+        rtm_dst_len: 0,
+        rtm_src_len: 0,
+        rtm_tos: 0,
+        rtm_table: RtTable::Unspec,
+        rtm_protocol: Rtprot::Unspec,
+        rtm_scope: RtScope::Universe,
+        rtm_type: Rtn::Unspec,
+        rtm_flags: RtmFFlags::new(&[RtmF::LookupTable]),
+        rtattrs: RtBuffer::new(),
+    };
+    let netlink_message = Nlmsghdr::new(
+        None,
+        Rtm::Getaddr,
+        NlmFFlags::new(&[NlmF::Request, NlmF::Dump]),
+        None,
+        None,
+        NlPayload::Payload(ifroutemsg),
+    );
+
+    netlink_socket
+        .send(netlink_message)
+        .map_err(|err| Error::StrategyError(err.to_string()))?;
+
+    let mut interfaces = Vec::new();
+
+    for response in netlink_socket.iter(false) {
+        let header: Nlmsghdr<Rtm, Ifaddrmsg> = response.map_err(|err| {
+            Error::StrategyError(format!(
+                "An error occurred retrieving Netlink's socket response: {err}"
+            ))
+        })?;
+
+        if let NlPayload::Empty = header.nl_payload {
+            continue;
+        }
+
+        if header.nl_type != Rtm::Newaddr {
+            return Err(Error::StrategyError(String::from(
+                "The Netlink header type is not the expected",
+            )));
+        }
+
+        let p = header.get_payload().map_err(|_| {
+            Error::StrategyError(String::from(
+                "An error occurred getting Netlink's header payload",
+            ))
+        })?;
+
+        if p.ifa_family != Inet6 && p.ifa_family != Inet {
+            Err(Error::StrategyError(format!(
+                "Netlink payload has unsupported family: {:?}",
+                p.ifa_family
+            )))?
+        }
+
+        let mut ipaddr = None;
+
+        for rtattr in p.rtattrs.iter() {
+            if rtattr.rta_type == Ifa::Label {
+                let ifname = String::from_utf8_lossy(rtattr.payload().as_ref()).to_string();
+                if_indexes.insert(p.ifa_index, ifname);
+            } else if rtattr.rta_type == Ifa::Address {
+                if ipaddr.is_some() {
+                    // do not override IFA_LOCAL
+                    continue;
+                }
+                if p.ifa_family == Inet6 {
+                    let rtaddr = Ipv6Addr::from(u128::from_be(
+                        rtattr.get_payload_as::<u128>().map_err(|_| {
+                            Error::StrategyError(String::from(
+                                "An error occurred retrieving Netlink's route payload attribute",
+                            ))
+                        })?,
+                    ));
+                    ipaddr = Some(IpAddr::V6(rtaddr));
+                } else {
+                    let rtaddr = Ipv4Addr::from(u32::from_be(
+                        rtattr.get_payload_as::<u32>().map_err(|_| {
+                            Error::StrategyError(String::from(
+                                "An error occurred retrieving Netlink's route payload attribute",
+                            ))
+                        })?,
+                    ));
+                    ipaddr = Some(IpAddr::V4(rtaddr));
+                }
+            } else if rtattr.rta_type == Ifa::Local {
+                if p.ifa_family == Inet6 {
+                    let rtlocal = Ipv6Addr::from(u128::from_be(
+                        rtattr.get_payload_as::<u128>().map_err(|_| {
+                            Error::StrategyError(String::from(
+                                "An error occurred retrieving Netlink's route payload attribute",
+                            ))
+                        })?,
+                    ));
+                    ipaddr = Some(IpAddr::V6(rtlocal));
+                } else {
+                    let rtlocal = Ipv4Addr::from(u32::from_be(
+                        rtattr.get_payload_as::<u32>().map_err(|_| {
+                            Error::StrategyError(String::from(
+                                "An error occurred retrieving Netlink's route payload attribute",
+                            ))
+                        })?,
+                    ));
+                    ipaddr = Some(IpAddr::V4(rtlocal));
+                }
+            }
+        }
+
+        if let Some(ipaddr) = ipaddr {
+            if let Some(ifname) = if_indexes.get(&p.ifa_index) {
+                interfaces.push((ifname.clone(), ipaddr));
+            }
+        }
+    }
+
+    Ok(interfaces)
 }


### PR DESCRIPTION
Rewrite the Linux version of `list_afinet_netifas()` using netlink requests in pure Rust instead of calling the libc interface `getifaddrs(3)`.  This avoids pointer magic and calling unsafe C code.
See https://github.com/EstebanBorai/local-ip-address/pull/88 and https://github.com/EstebanBorai/local-ip-address/pull/93 for exemplary issues.


Based on #102