### PR TITLE
linux: manually set netlink message sizes

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -267,7 +267,7 @@ pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
         rtattrs: RtBuffer::new(),
     };
     let netlink_message = Nlmsghdr::new(
-        None,
+        Some(20),
         Rtm::Getlink,
         NlmFFlags::new(&[NlmF::Request, NlmF::Dump]),
         None,
@@ -328,7 +328,7 @@ pub fn list_afinet_netifas() -> Result<Vec<(String, IpAddr)>, Error> {
         rtattrs: RtBuffer::new(),
     };
     let netlink_message = Nlmsghdr::new(
-        None,
+        Some(20),
         Rtm::Getaddr,
         NlmFFlags::new(&[NlmF::Request, NlmF::Dump]),
         None,


### PR DESCRIPTION
The underlying netlink library neli seems to compute the size of the netlink messages incorrectly, leading to the kernel issuing warnings like:

    kernel: netlink: 8 bytes leftover after parsing attributes in process `example'.