### PR TITLE
feat(linux): `local_broadcast_ip` function

### DIFF
--- a/examples/show_ip_and_ifs.rs
+++ b/examples/show_ip_and_ifs.rs
@@ -2,8 +2,10 @@ use local_ip_address::{
     list_afinet_netifas, 
     local_ip, 
     local_ipv6, 
-    local_broadcast_ip,
 };
+// this is only supported on linux currently
+#[cfg(target_os = "linux")]
+use local_ip_address::local_broadcast_ip;
 
 fn main() {
     match local_ip() {

--- a/examples/show_ip_and_ifs.rs
+++ b/examples/show_ip_and_ifs.rs
@@ -1,8 +1,4 @@
-use local_ip_address::{
-    list_afinet_netifas, 
-    local_ip, 
-    local_ipv6, 
-};
+use local_ip_address::{list_afinet_netifas, local_ip, local_ipv6};
 // this is only supported on linux currently
 #[cfg(target_os = "linux")]
 use local_ip_address::local_broadcast_ip;
@@ -35,4 +31,3 @@ fn main() {
         Err(err) => println!("Failed to get list of network interfaces: {}", err),
     };
 }
-

--- a/examples/show_ip_and_ifs.rs
+++ b/examples/show_ip_and_ifs.rs
@@ -16,6 +16,8 @@ fn main() {
         Err(err) => println!("Failed to get local IPv6: {}", err),
     };
 
+    // this is only supported on linux currently
+    #[cfg(target_os = "linux")]
     match local_broadcast_ip() {
         Ok(ip) => println!("Local broadcast IPv4: {}", ip),
         Err(err) => println!("Failed to get local broadcast IPv4: {}", err),

--- a/examples/show_ip_and_ifs.rs
+++ b/examples/show_ip_and_ifs.rs
@@ -1,4 +1,9 @@
-use local_ip_address::{list_afinet_netifas, local_ip, local_ipv6};
+use local_ip_address::{
+    list_afinet_netifas, 
+    local_ip, 
+    local_ipv6, 
+    local_broadcast_ip,
+};
 
 fn main() {
     match local_ip() {
@@ -11,6 +16,11 @@ fn main() {
         Err(err) => println!("Failed to get local IPv6: {}", err),
     };
 
+    match local_broadcast_ip() {
+        Ok(ip) => println!("Local broadcast IPv4: {}", ip),
+        Err(err) => println!("Failed to get local broadcast IPv4: {}", err),
+    };
+
     match list_afinet_netifas() {
         Ok(netifs) => {
             println!("Got {} interfaces", netifs.len());
@@ -21,3 +31,4 @@ fn main() {
         Err(err) => println!("Failed to get list of network interfaces: {}", err),
     };
 }
+

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -43,119 +43,8 @@ fn local_broadcast_impl(family: RtAddrFamily) -> Result<IpAddr, Error> {
     let mut netlink_socket = NlSocketHandle::connect(NlFamily::Route, None, &[])
         .map_err(|err| Error::StrategyError(err.to_string()))?;
 
-    let route_attr = match family {
-        Inet => {
-            let dstip = Ipv4Addr::new(192, 0, 2, 0); // reserved external IP
-            let raw_dstip = u32::from(dstip).to_be();
-            Rtattr::new(None, Rta::Dst, raw_dstip)
-        }
-        Inet6 => {
-            let dstip = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0); // reserved external IP
-            let raw_dstip = u128::from(dstip).to_be();
-            Rtattr::new(None, Rta::Dst, raw_dstip)
-        }
-        _ => Err(Error::StrategyError(format!(
-            "Invalid address family given: {:#?}",
-            family
-        )))?,
-    };
+    let pref_ip = local_ip()?;
 
-    let route_attr = route_attr.map_err(|err| Error::StrategyError(err.to_string()))?;
-    let mut route_payload = RtBuffer::new();
-    route_payload.push(route_attr);
-    let ifroutemsg = Rtmsg {
-        rtm_family: family,
-        rtm_dst_len: 0,
-        rtm_src_len: 0,
-        rtm_tos: 0,
-        rtm_table: RtTable::Unspec,
-        rtm_protocol: Rtprot::Unspec,
-        rtm_scope: RtScope::Universe,
-        rtm_type: Rtn::Unspec,
-        rtm_flags: RtmFFlags::new(RTM_FLAGS_LOOKUP),
-        rtattrs: route_payload,
-    };
-    let netlink_message = Nlmsghdr::new(
-        None,
-        Rtm::Getroute,
-        NlmFFlags::new(&[NlmF::Request]),
-        None,
-        None,
-        NlPayload::Payload(ifroutemsg),
-    );
-
-    netlink_socket
-        .send(netlink_message)
-        .map_err(|err| Error::StrategyError(err.to_string()))?;
-
-    let mut pref_ip = None;
-    for response in netlink_socket.iter(false) {
-        if pref_ip.is_some() {
-            break;
-        }
-        let header: Nlmsghdr<Rtm, Rtmsg> = response.map_err(|err| {
-            if let Nlmsgerr(ref err) = err {
-                if err.error == -libc::ENETUNREACH {
-                    return Error::LocalIpAddressNotFound;
-                }
-            }
-            Error::StrategyError(format!(
-                "An error occurred retrieving Netlink's socket response: {err}",
-            ))
-        })?;
-
-        if let NlPayload::Empty = header.nl_payload {
-            continue;
-        }
-
-        if header.nl_type != Rtm::Newroute {
-            return Err(Error::StrategyError(String::from(
-                "The Netlink header type is not the expected",
-            )));
-        }
-
-        let p = header.get_payload().map_err(|_| {
-            Error::StrategyError(String::from(
-                "An error occurred getting Netlink's header payload",
-            ))
-        })?;
-
-        if p.rtm_scope != RtScope::Universe {
-            continue;
-        }
-
-        if p.rtm_family != family {
-            Err(Error::StrategyError(format!(
-                "Invalid address family in Netlink payload: {:?}",
-                p.rtm_family
-            )))?
-        }
-
-        for rtattr in p.rtattrs.iter() {
-            if rtattr.rta_type == Rta::Prefsrc {
-                if p.rtm_family == Inet {
-                    let addr = Ipv4Addr::from(u32::from_be(
-                        rtattr.get_payload_as::<u32>().map_err(|_| {
-                            Error::StrategyError(String::from(
-                                "An error occurred retrieving Netlink's route payload attribute",
-                            ))
-                        })?,
-                    ));
-                    pref_ip = Some(IpAddr::V4(addr));
-                    break;
-                }
-                let addr = Ipv6Addr::from(u128::from_be(
-                    rtattr.get_payload_as::<u128>().map_err(|_| {
-                        Error::StrategyError(String::from(
-                            "An error occurred retrieving Netlink's route payload attribute",
-                        ))
-                    })?,
-                ));
-                pref_ip = Some(IpAddr::V6(addr));
-                break;
-            }
-        }
-    }
 
     let ifaddrmsg = Ifaddrmsg {
         ifa_family: family,
@@ -224,7 +113,7 @@ fn local_broadcast_impl(family: RtAddrFamily) -> Result<IpAddr, Error> {
                             ))
                         })?,
                     ));
-                    is_match = pref_ip == Some(IpAddr::V4(addr));
+                    is_match = pref_ip == IpAddr::V4(addr);
                 } else {
                     let addr = Ipv6Addr::from(u128::from_be(
                         rtattr.get_payload_as::<u128>().map_err(|_| {
@@ -233,7 +122,7 @@ fn local_broadcast_impl(family: RtAddrFamily) -> Result<IpAddr, Error> {
                             ))
                         })?,
                     ));
-                    is_match = pref_ip == Some(IpAddr::V6(addr));
+                    is_match = pref_ip == IpAddr::V6(addr);
                 }
             }
             if is_match {


### PR DESCRIPTION
<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
In reference to  #133. This PR adds access to the broadcast ip. A broadcast ip is only a ipv4 feature which is why there is no ipv6 function. The neli crate provided the broadcast ip directly, so I decided to access that instead of netmask. 

Broadcast ip can now be accessed via `local_broadcast_ip()`. 