### PR TITLE
fix(linux): can't get local ip address with libc::ENETUNREACH error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
     /// Returned when `local_ip` is unable to find the system's local IP address
     /// in the collection of network interfaces

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -164,7 +164,10 @@ fn local_ip_impl(family: RtAddrFamily) -> Result<IpAddr, Error> {
     }
 }
 
-fn local_ip_impl_route(family: RtAddrFamily, netlink_socket: &mut NlSocketHandle) -> Result<IpAddr, Error> {
+fn local_ip_impl_route(
+    family: RtAddrFamily,
+    netlink_socket: &mut NlSocketHandle,
+) -> Result<IpAddr, Error> {
     let route_attr = match family {
         Inet => {
             let dstip = Ipv4Addr::new(192, 0, 2, 0); // reserved external IP
@@ -276,7 +279,10 @@ fn local_ip_impl_route(family: RtAddrFamily, netlink_socket: &mut NlSocketHandle
     Err(Error::LocalIpAddressNotFound)
 }
 
-fn local_ip_impl_addr(family: RtAddrFamily, netlink_socket: &mut NlSocketHandle) -> Result<IpAddr, Error> {
+fn local_ip_impl_addr(
+    family: RtAddrFamily,
+    netlink_socket: &mut NlSocketHandle,
+) -> Result<IpAddr, Error> {
     let ifaddrmsg = Ifaddrmsg {
         ifa_family: family,
         ifa_prefixlen: 0,

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -160,9 +160,7 @@ fn local_ip_impl(family: RtAddrFamily) -> Result<IpAddr, Error> {
 
     match local_ip_impl_route(family, &mut netlink_socket) {
         Ok(ip_addr) => Ok(ip_addr),
-        Err(error) if error == Error::LocalIpAddressNotFound => {
-            local_ip_impl_addr(family, &mut netlink_socket)
-        }
+        Err(Error::LocalIpAddressNotFound) => local_ip_impl_addr(family, &mut netlink_socket),
         Err(e) => Err(e),
     }
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -160,7 +160,10 @@ fn local_ip_impl(family: RtAddrFamily) -> Result<IpAddr, Error> {
 
     match local_ip_impl_route(family, &mut netlink_socket) {
         Ok(ip_addr) => Ok(ip_addr),
-        Err(_error) => local_ip_impl_addr(family, &mut netlink_socket),
+        Err(error) if error == Error::LocalIpAddressNotFound => {
+            local_ip_impl_addr(family, &mut netlink_socket)
+        }
+        Err(e) => Err(e),
     }
 }
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -158,6 +158,13 @@ fn local_ip_impl(family: RtAddrFamily) -> Result<IpAddr, Error> {
     let mut netlink_socket = NlSocketHandle::connect(NlFamily::Route, None, &[])
         .map_err(|err| Error::StrategyError(err.to_string()))?;
 
+    match local_ip_impl_route(family, &mut netlink_socket) {
+        Ok(ip_addr) => Ok(ip_addr),
+        Err(_error) => local_ip_impl_addr(family, &mut netlink_socket),
+    }
+}
+
+fn local_ip_impl_route(family: RtAddrFamily, netlink_socket: &mut NlSocketHandle) -> Result<IpAddr, Error> {
     let route_attr = match family {
         Inet => {
             let dstip = Ipv4Addr::new(192, 0, 2, 0); // reserved external IP
@@ -266,7 +273,10 @@ fn local_ip_impl(family: RtAddrFamily) -> Result<IpAddr, Error> {
             }
         }
     }
+    Err(Error::LocalIpAddressNotFound)
+}
 
+fn local_ip_impl_addr(family: RtAddrFamily, netlink_socket: &mut NlSocketHandle) -> Result<IpAddr, Error> {
     let ifaddrmsg = Ifaddrmsg {
         ifa_family: family,
         ifa_prefixlen: 0,


### PR DESCRIPTION
Fix(linux): can not get local ip address when the network namespace without default route
#135 

