### PR TITLE
bumped windows-sys to v0.59.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2"
 neli = "0.6"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48.0"
+version = "0.59.0"
 features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -10,7 +10,7 @@ use std::{
 
 use windows_sys::Win32::{
     Foundation::{
-        GetLastError, BOOL, ERROR_ADDRESS_NOT_ASSOCIATED, ERROR_BUFFER_OVERFLOW,
+        GetLastError, LocalFree, BOOL, ERROR_ADDRESS_NOT_ASSOCIATED, ERROR_BUFFER_OVERFLOW,
         ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_PARAMETER, ERROR_NOT_ENOUGH_MEMORY,
         ERROR_NOT_SUPPORTED, ERROR_NO_DATA, ERROR_SUCCESS, WIN32_ERROR,
     },
@@ -21,11 +21,8 @@ use windows_sys::Win32::{
     Networking::WinSock::{
         ADDRESS_FAMILY, AF_INET, AF_INET6, AF_UNSPEC, SOCKADDR_IN, SOCKADDR_IN6, SOCKADDR,
     },
-    System::{
-        Diagnostics::Debug::{
+    System::Diagnostics::Debug::{
             FormatMessageW, FORMAT_MESSAGE_ALLOCATE_BUFFER, FORMAT_MESSAGE_FROM_SYSTEM,
-        },
-        Memory::LocalFree,
     },
 };
 
@@ -260,7 +257,7 @@ fn format_error_code(error_code: WIN32_ERROR) -> String {
     let error_message = String::from_utf16_lossy(slice);
 
     unsafe {
-        LocalFree(wide_ptr as isize);
+        LocalFree(&mut wide_ptr as *mut _ as *mut _);
     }
 
     error_message


### PR DESCRIPTION
windows.rs needed changed due to LocalFree method call being moved to windows_sys::Win32::foundation, and pointer passed to LocalFree requires *mut c_void now (not sure if the fix I did is correct, but it compiles and the example works)

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
